### PR TITLE
Fix interpolations warnings and make updates for Julia 1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,12 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
   - 0.7
   - nightly
 notifications:
   email: false
 branches:
   only: master
-matrix:
-  allow_failures:
-    - julia: 0.7
-    - julia: nightly
 git:
   depth: 999999999
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 StaticArrays 0.3
 Interpolations 0.3
 RegionTrees 0.0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 StaticArrays 0.3
 Interpolations 0.3
 RegionTrees 0.0.3

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -9,7 +9,8 @@ using Interpolations: interpolate!,
                       AbstractInterpolation,
                       BSpline,
                       OnGrid,
-                      Linear
+                      Linear,
+                      Line
 using StaticArrays: SVector
 
 export AdaptiveDistanceField,

--- a/src/adaptivesampling.jl
+++ b/src/adaptivesampling.jl
@@ -23,6 +23,6 @@ end
 
 function refine_data(refinery::SignedDistanceRefinery, boundary::HyperRectangle)
     extrapolate(interpolate!(refinery.signed_distance_func.(vertices(boundary)),
-                             BSpline(Linear()),
-                             OnGrid()), Linear())
+                             BSpline(Linear())),
+                             Line())
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -1,5 +1,5 @@
 @generated function evaluate(itp::AbstractInterpolation, point::SVector{N}) where N
-    Expr(:ref, :itp, [:(point[$i]) for i in 1:N]...)
+    Expr(:call, :itp, [:(point[$i]) for i in 1:N]...)
 end
 
 function evaluate(itp::AbstractInterpolation, point::AbstractArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 import ForwardDiff  # Needs to be first due to https://github.com/JuliaMath/Interpolations.jl/issues/207
 using AdaptiveDistanceFields
-using Base.Test
+using Test
 using StaticArrays: SVector
 
 @testset "coarse" begin
@@ -9,8 +9,8 @@ using StaticArrays: SVector
     s = x -> sqrt(sum((x - SVector(1, 2)).^2))
     adf = AdaptiveDistanceField(s, SVector(-1., -1), SVector(5., 5), rtol, atol)
 
-    for x in linspace(-1, 4)
-        for y in linspace(-1, 4)
+    for x in range(-1,4,length=50)
+        for y in range(-1,4,length=50)
             @test isapprox(adf(SVector(x, y)), s(SVector(x, y)), atol=atol, rtol=rtol)
         end
     end
@@ -22,8 +22,8 @@ end
     s = x -> sqrt(sum((x - SVector(-2, -1)).^2))
     adf = AdaptiveDistanceField(s, SVector(-5., -5), SVector(10., 10), rtol, atol)
 
-    for x in linspace(-5, 5)
-        for y in linspace(-5, 5)
+    for x in range(-5,5,length=50)
+        for y in range(-5,5,length=50)
             @test isapprox(adf(SVector(x, y)), s(SVector(x, y)), atol=0.005, rtol=0.005)
         end
     end


### PR DESCRIPTION
These are some fixes to make this package run on Julia 1.0 and with the current version of interpolations. 