### PR TITLE
Add field gradient and hessian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,11 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 RegionTrees = "dee08c22-ab7f-5625-9660-a9af2021b33f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[compat]
+Interpolations = "0.9, 0.10, 0.11, 0.12"
+RegionTrees = "0.3"
+julia = "1"
+
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Interpolations = "0.9, 0.10, 0.11, 0.12"
-RegionTrees = "0.3"
+RegionTrees = "0.2, 0.3"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,6 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 RegionTrees = "dee08c22-ab7f-5625-9660-a9af2021b33f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
-[compat]
-Interpolations = "0.9, 0.10, 0.11"
-RegionTrees = "0.2"
-julia = "1"
-
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -6,13 +6,14 @@ using RegionTrees
 import RegionTrees: needs_refinement, refine_data
 using Interpolations: interpolate!,
                       extrapolate,
+                      gradient,
+                      hessian,
                       AbstractInterpolation,
                       BSpline,
                       OnGrid,
                       Linear,
                       Line
-import Interpolations.gradient
-import Interpolations.hessian
+
 using StaticArrays: SVector
 
 export AdaptiveDistanceField,

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -15,6 +15,7 @@ using StaticArrays: SVector
 
 export AdaptiveDistanceField,
        evaluate,
+       gradient,
        ConvexMesh
 
 include("interpolation.jl")

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -45,6 +45,10 @@ function (field::AdaptiveDistanceField)(point::AbstractArray)
 end
 
 
+function fieldgradient(field::AdaptiveDistanceField,point::AbstractArray)
+    fieldgradient(field.root, point)
+end
+
 function fieldhessian(field::AdaptiveDistanceField,point::AbstractArray)
     fieldhessian(field.root, point)
 end

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -6,6 +6,7 @@ using RegionTrees
 import RegionTrees: needs_refinement, refine_data
 using Interpolations: interpolate!,
                       extrapolate,
+                      gradient,
                       AbstractInterpolation,
                       BSpline,
                       OnGrid,

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -40,4 +40,9 @@ function (field::AdaptiveDistanceField)(point::AbstractArray)
     evaluate(field.root, point)
 end
 
+
+function gradient(field::AdaptiveDistanceField,point::AbstractArray)
+    gradient(field.root, point)
+end
+
 end

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -6,17 +6,17 @@ using RegionTrees
 import RegionTrees: needs_refinement, refine_data
 using Interpolations: interpolate!,
                       extrapolate,
-                      gradient,
                       AbstractInterpolation,
                       BSpline,
                       OnGrid,
                       Linear,
                       Line
+import Interpolations.gradient
 using StaticArrays: SVector
 
 export AdaptiveDistanceField,
        evaluate,
-       gradient,
+       fieldgradient,
        ConvexMesh
 
 include("interpolation.jl")
@@ -42,8 +42,8 @@ function (field::AdaptiveDistanceField)(point::AbstractArray)
 end
 
 
-function gradient(field::AdaptiveDistanceField,point::AbstractArray)
-    gradient(field.root, point)
+function fieldgradient(field::AdaptiveDistanceField,point::AbstractArray)
+    fieldgradient(field.root, point)
 end
 
 end

--- a/src/AdaptiveDistanceFields.jl
+++ b/src/AdaptiveDistanceFields.jl
@@ -12,11 +12,13 @@ using Interpolations: interpolate!,
                       Linear,
                       Line
 import Interpolations.gradient
+import Interpolations.hessian
 using StaticArrays: SVector
 
 export AdaptiveDistanceField,
        evaluate,
        fieldgradient,
+       fieldhessian,
        ConvexMesh
 
 include("interpolation.jl")
@@ -42,8 +44,8 @@ function (field::AdaptiveDistanceField)(point::AbstractArray)
 end
 
 
-function fieldgradient(field::AdaptiveDistanceField,point::AbstractArray)
-    fieldgradient(field.root, point)
+function fieldhessian(field::AdaptiveDistanceField,point::AbstractArray)
+    fieldhessian(field.root, point)
 end
 
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -16,16 +16,16 @@ function evaluate(interp::AbstractInterpolation, boundary::HyperRectangle, point
     evaluate(interp, coords)
 end
 
-function gradient(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
+function fieldgradient(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
     leaf = findleaf(cell, point)
-    gradient(leaf.data, leaf.boundary, point)
+    fieldgradient(leaf.data, leaf.boundary, point)
 end
 
-function gradient(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
+function fieldgradient(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
     coords = (point - boundary.origin) ./ boundary.widths .+ 1
-    gradient(interp, coords) ./ boundary.widths
+    fieldgradient(interp, coords) ./ boundary.widths
 end
 
-function gradient(itp::AbstractInterpolation, point::AbstractArray)
+function fieldgradient(itp::AbstractInterpolation, point::AbstractArray)
     gradient(itp, point...)
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -3,7 +3,7 @@
 end
 
 function evaluate(itp::AbstractInterpolation, point::AbstractArray)
-    itp[point...]
+    itp(point...)
 end
 
 function evaluate(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -27,5 +27,5 @@ function gradient(interp::AbstractInterpolation, boundary::HyperRectangle, point
 end
 
 function gradient(itp::AbstractInterpolation, point::AbstractArray)
-    Interpolations.gradient(itp, point...)
+    gradient(itp, point...)
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -15,3 +15,17 @@ function evaluate(interp::AbstractInterpolation, boundary::HyperRectangle, point
     coords = (point - boundary.origin) ./ boundary.widths .+ 1
     evaluate(interp, coords)
 end
+
+function gradient(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
+    leaf = findleaf(cell, point)
+    gradient(leaf.data, leaf.boundary, point)
+end
+
+function gradient(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
+    coords = (point - boundary.origin) ./ boundary.widths .+ 1
+    gradient(interp, coords) ./ boundary.widths
+end
+
+function gradient(itp::AbstractInterpolation, point::AbstractArray)
+    Interpolations.gradient(itp, point...)
+end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -12,6 +12,6 @@ function evaluate(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInter
 end
 
 function evaluate(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
-    coords = (point - boundary.origin) ./ boundary.widths + 1
+    coords = (point - boundary.origin) ./ boundary.widths .+ 1
     evaluate(interp, coords)
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -40,7 +40,7 @@ end
 
 function fieldhessian(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
     coords = (point - boundary.origin) ./ boundary.widths .+ 1
-    fieldhessian(interp, coords) ./ boundary.widths
+    fieldhessian(interp, coords) ./ reduce(hcat, boundary.widths for _ in 1:length(point))
 end
 
 function fieldhessian(itp::AbstractInterpolation, point::AbstractArray)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -16,6 +16,8 @@ function evaluate(interp::AbstractInterpolation, boundary::HyperRectangle, point
     evaluate(interp, coords)
 end
 
+
+
 function fieldgradient(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
     leaf = findleaf(cell, point)
     fieldgradient(leaf.data, leaf.boundary, point)
@@ -28,4 +30,19 @@ end
 
 function fieldgradient(itp::AbstractInterpolation, point::AbstractArray)
     gradient(itp, point...)
+end
+
+
+function fieldhessian(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
+    leaf = findleaf(cell, point)
+    fieldhessian(leaf.data, leaf.boundary, point)
+end
+
+function fieldhessian(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
+    coords = (point - boundary.origin) ./ boundary.widths .+ 1
+    fieldhessian(interp, coords) ./ boundary.widths
+end
+
+function fieldhessian(itp::AbstractInterpolation, point::AbstractArray)
+    hessian(itp, point...)
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -18,6 +18,12 @@ end
 
 
 
+
+
+@generated function fieldgradient(itp::AbstractInterpolation, point::SVector{N}) where N
+    Expr(:call, :gradient, :itp, [:(point[$i]) for i in 1:N]...)
+end
+
 function fieldgradient(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
     leaf = findleaf(cell, point)
     fieldgradient(leaf.data, leaf.boundary, point)
@@ -32,6 +38,13 @@ function fieldgradient(itp::AbstractInterpolation, point::AbstractArray)
     gradient(itp, point...)
 end
 
+
+
+
+
+@generated function fieldhessian(itp::AbstractInterpolation, point::SVector{N}) where N
+    Expr(:call, :hessian, :itp, [:(point[$i]) for i in 1:N]...)
+end
 
 function fieldhessian(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInterpolation}
     leaf = findleaf(cell, point)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -40,7 +40,7 @@ end
 
 function fieldhessian(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
     coords = (point - boundary.origin) ./ boundary.widths .+ 1
-    fieldhessian(interp, coords) ./ reduce(hcat, boundary.widths for _ in 1:length(point))
+    fieldhessian(interp, coords) ./ reduce(vcat, boundary.widths' for _ in 1:length(point))
 end
 
 function fieldhessian(itp::AbstractInterpolation, point::AbstractArray)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -40,7 +40,7 @@ end
 
 function fieldhessian(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
     coords = (point - boundary.origin) ./ boundary.widths .+ 1
-    fieldhessian(interp, coords) ./ reduce(vcat, boundary.widths' for _ in 1:length(point))
+    fieldhessian(interp, coords) ./ (boundary.widths*boundary.widths')
 end
 
 function fieldhessian(itp::AbstractInterpolation, point::AbstractArray)


### PR DESCRIPTION
This commit adds the ability to get the field gradient and hessian by calling `fieldgradient` and `fieldhessian` at a point. This makes use of the `gradient` and `hessian` functions in Interpolations.jl. 

Note : I also updated compatibilities