### PR TITLE
[WIP] allow Interpolations 0.14 and RegionTrees 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ RegionTrees = "dee08c22-ab7f-5625-9660-a9af2021b33f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13 0.14"
+Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14"
 RegionTrees = "0.2, 0.3"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ RegionTrees = "dee08c22-ab7f-5625-9660-a9af2021b33f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Interpolations = "0.9, 0.10, 0.11"
-RegionTrees = "0.2"
+Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13 0.14"
+RegionTrees = "0.2, 0.3"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ atol = 1e-2
 adf = AdaptiveDistanceField(true_signed_distance, origin, widths, rtol, atol)
 ```
 
-The meanings of `rtol` and `atol` are equivalent to those used by the built-in `isapprox()`: a cell is divided if `norm(true - approximate) <= atol + rtol*max(norm(true), norm(approximate))`, evaluated at the center of the cell and and the center of each of its faces. 
+The meanings of `rtol` and `atol` are equivalent to those used by the built-in `isapprox()`: a cell is divided unless `norm(true - approximate) <= atol + rtol*max(norm(true), norm(approximate))` at the center of the cell and and the center of each of its faces. 
 
 ## Using meshes
 

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -12,6 +12,6 @@ function evaluate(cell::Cell{D}, point::AbstractArray) where {D <: AbstractInter
 end
 
 function evaluate(interp::AbstractInterpolation, boundary::HyperRectangle, point::AbstractArray)
-    coords = (point - boundary.origin) ./ boundary.widths + 1
+    coords = (point - boundary.origin) ./ boundary.widths .+ 1
     evaluate(interp, coords)
 end


### PR DESCRIPTION
bump compatibility 

especially useful for using newer versions (after 1.0) of StaticArrays

I get MethodError now. Seems to be due to a change in StaticArrays, where addition of a SVector and a Scalar does not work anymore